### PR TITLE
Fix: change import for AnnotatedMeter for preamble of interactive exa…

### DIFF
--- a/src/docs/components/annotated-meter/AnnotatedMeterExamplesDoc.js
+++ b/src/docs/components/annotated-meter/AnnotatedMeterExamplesDoc.js
@@ -33,7 +33,7 @@ export default class AnnotatedMeterExamplesDoc extends Component {
       <InteractiveExample contextLabel='AnnotatedMeter'
         contextPath='/docs/annotated-meter'
         preamble={
-          `import AnnotatedMeter from 'grommet/components/AnnotatedMeter';`
+          `import AnnotatedMeter from 'grommet-addons/components/AnnotatedMeter';`
         }
         propsSchema={PROPS_SCHEMA}
         element={element}


### PR DESCRIPTION
…mple

According to #1125, the import statement was incorrect for the AnnotatedMeter example.  This should fix it so that the interactive example imports correctly from grommet-addons.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix the annotated meter example

#### Where should the reviewer start?
See here: https://github.com/grommet/grommet-docs/blob/master/src/docs/components/annotated-meter/AnnotatedMeterExamplesDoc.js#L36/  The import statement was misleading that AnnotatedMeter was imported directly from the grommet-core package.

#### What testing has been done on this PR?
Test that import statement is correct on docs website.

#### How should this be manually tested?
After deployment, visit website to confirm that annotatemeter component import is correct.

#### Any background context you want to provide?
See: https://github.com/grommet/grommet/issues/1125

#### What are the relevant issues?
#[1125](https://github.com/grommet/grommet/issues/1125) on grommet-core

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/13810084/21767296/42a0e7e4-d641-11e6-9a40-09076ce8082e.png)
![image](https://cloud.githubusercontent.com/assets/13810084/21767462/5acca4c4-d642-11e6-820c-b8c2c632b647.png)
